### PR TITLE
Add check for shout privileges

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,8 +1,10 @@
 minetest.register_on_chat_message(function(name, message)
-	local pos = minetest.get_player_by_name(name):getpos()
-	local text = minetest.add_entity(pos, "chat_bubbles:text")
-	text:get_luaentity().text = message
-	text:set_attach(minetest.get_player_by_name(name), "", {x=0,y=15,z=0},{x=0,y=0,z=0})
+	if minetest.get_player_privs(name).shout then
+		local pos = minetest.get_player_by_name(name):getpos()
+		local text = minetest.add_entity(pos, "chat_bubbles:text")
+		text:get_luaentity().text = message
+		text:set_attach(minetest.get_player_by_name(name), "", {x=0,y=15,z=0},{x=0,y=0,z=0})
+	end
 end)
 
 minetest.register_entity("chat_bubbles:text", {


### PR DESCRIPTION
To close a loophole that allows players without shout privilege to talk through chat bubbles. More or less a QoL tweak for server admins.